### PR TITLE
Support linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,72 +10,74 @@ pub fn build(b: *std.Build) void {
     // means any target is allowed, and the default is native. Other options
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
-    
+
     // Standard optimization options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
-    
+
     const exe = b.addExecutable(.{
         .name = "game",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
         .root_source_file = b.path("src/main.zig"),
         .target = target,
-        .optimize = optimize
+        .optimize = optimize,
     });
     exe.linkLibC();
-    
+
     if (builtin.os.tag == .windows) {
         exe.addIncludePath(b.path("lib/SDL2/include"));
         exe.addIncludePath(b.path("lib/SDL2_image/include"));
-        
+
         exe.addLibraryPath(b.path("lib/SDL2/lib/x64"));
         exe.addLibraryPath(b.path("lib/SDL2_image/lib/x64"));
-        
+
         exe.linkSystemLibrary("SDL2");
         exe.linkSystemLibrary("SDL2_image");
     } else if (builtin.os.tag == .macos) {
         exe.addIncludePath(.{ .cwd_relative = "/opt/homebrew/include" });
-        
+
+        exe.linkSystemLibrary("SDL2");
+        exe.linkSystemLibrary("SDL2_image");
+    } else if (builtin.os.tag == .linux) {
+        exe.addIncludePath(.{ .cwd_relative = "/usr/include" });
+
         exe.linkSystemLibrary("SDL2");
         exe.linkSystemLibrary("SDL2_image");
     }
     exe.addIncludePath(b.path("lib/glad/include"));
-    exe.addCSourceFile(.{
-        .file = b.path("lib/glad/src/glad.c"),
-        .flags = &.{}
-    });
+    exe.addCSourceFile(.{ .file = b.path("lib/glad/src/glad.c"), .flags = &.{} });
     // exe.strip = true;
-    
+
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).
     b.installArtifact(exe);
-    
+
     // This *creates* a Run step in the build graph, to be executed when another
     // step is evaluated that depends on it. The next line below will establish
     // such a dependency.
     const run_cmd = b.addRunArtifact(exe);
-    
+
     // By making the run step depend on the install step, it will be run from the
     // installation directory rather than directly from within the cache directory.
     // This is not necessary, however, if the application depends on other installed
     // files, this ensures they will be present and in the expected location.
     run_cmd.step.dependOn(b.getInstallStep());
-    
+
     // This allows the user to pass arguments to the application in the build
     // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
-    
+
     // This creates a build step. It will be visible in the `zig build --help` menu,
     // and can be selected like this: `zig build run`
     // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
-    
+
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const unit_tests = b.addTest(.{
@@ -83,9 +85,9 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    
+
     const run_unit_tests = b.addRunArtifact(unit_tests);
-    
+
     // Similar to creating the run step earlier, this exposes a `test` step to
     // the `zig build --help` menu, providing a way for the user to request
     // running the unit tests.


### PR DESCRIPTION
This pull request mainly supports linux by adding the include path `/usr/include` and linking the system libraries.  
Furthermore, as I have autoformat on save activated, the build.zig file is formatted by `zig fmt`. 